### PR TITLE
Change fixpat value for much better graphical performance

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -1654,7 +1654,7 @@
 				<key>MinKernel</key>
 				<string>17.0.0</string>
 				<key>Replace</key>
-				<data>uXcCAAC4BgEHALoGAQcADx9AAA==</data>
+				<data>uXcCAAC4BgYGBroGBgYGDzAPCQ==</data>
 				<key>ReplaceMask</key>
 				<data></data>
 				<key>Skip</key>


### PR DESCRIPTION
The previous value seemed to be for TRX40 users, changing to the correct value yields much better graphical performance.
https://github.com/AMD-OSX/bugtracker/issues/5#issuecomment-713014120

WARNING: This may break displayport audio, look at the issue for further info regarding the patch